### PR TITLE
 Delete the folders created in calenderout

### DIFF
--- a/classes/class.ilUnibeFileHandlerGUI.php
+++ b/classes/class.ilUnibeFileHandlerGUI.php
@@ -184,8 +184,10 @@ class ilUnibeFileHandlerGUI extends AbstractCtrlAwareUploadHandler
             $temp = $DIC->filesystem()->storage();
             $store = $DIC->filesystem()->storage();
             foreach($temp->listContents('calendarout/')as $file) {
+                if ($temp->hasDir($file->getPath())) {
                     $temp->deleteDir($file->getPath());
-                    }
+                }
+            }
             $temp_folder_name = 'calendarout/' .uniqid();
             foreach ($event_items as $item) {
                 if ($item['type'] == 'file') {

--- a/classes/class.ilUnibeFileHandlerGUI.php
+++ b/classes/class.ilUnibeFileHandlerGUI.php
@@ -183,9 +183,11 @@ class ilUnibeFileHandlerGUI extends AbstractCtrlAwareUploadHandler
         if (count($event_items)) {
             $temp = $DIC->filesystem()->storage();
             $store = $DIC->filesystem()->storage();
-            foreach($temp->listContents('calendarout/')as $file) {
-                if ($temp->hasDir($file->getPath())) {
-                    $temp->deleteDir($file->getPath());
+            if(count($temp->listContents('calendarout/'))>20) {
+                foreach ($temp->listContents('calendarout/') as $file) {
+                    if ($temp->hasDir($file->getPath())) {
+                        $temp->deleteDir($file->getPath());
+                    }
                 }
             }
             $temp_folder_name = 'calendarout/' .uniqid();

--- a/classes/class.ilUnibeFileHandlerGUI.php
+++ b/classes/class.ilUnibeFileHandlerGUI.php
@@ -181,9 +181,12 @@ class ilUnibeFileHandlerGUI extends AbstractCtrlAwareUploadHandler
 
 
         if (count($event_items)) {
-            $temp_folder_name = 'calendarout/' .uniqid();
             $temp = $DIC->filesystem()->storage();
             $store = $DIC->filesystem()->storage();
+            foreach($temp->listContents('calendarout/')as $file) {
+                    $temp->deleteDir($file->getPath());
+                    }
+            $temp_folder_name = 'calendarout/' .uniqid();
             foreach ($event_items as $item) {
                 if ($item['type'] == 'file') {
                     $files_count++;
@@ -214,7 +217,6 @@ class ilUnibeFileHandlerGUI extends AbstractCtrlAwareUploadHandler
                 $zip_options = $DIC->archives()->zipOptions()->withZipOutputPath($tmp_zip_folder)->withZipOutputName($download_name);
                 $zip = $DIC->archives()->zip($streams, $zip_options);
 
-                $temp->deleteDir($tmp_zip_folder);
                 $DIC->fileDelivery()->delivery()->attached(
                     $zip->get(),
                     $download_name,


### PR DESCRIPTION
As is was before the files only get deleted, wehn there is only one File to download from a session. the line 217 does not work there, because the zip file in that moment will still need to be used and the delete fails. With this change We will check how many folders are present in calenderout and then delete them, when its more than 20. 